### PR TITLE
set default encoding to utf8 in order to avoid ascii error when listing pushes on Mac OSX (compatibility with python < 3.x)

### DIFF
--- a/pushbullet_cli/app.py
+++ b/pushbullet_cli/app.py
@@ -9,6 +9,7 @@ import click
 import keyring
 import keyrings.alt
 import pushbullet
+from importlib import reload
 
 reload(sys)
 sys.setdefaultencoding('utf8')

--- a/pushbullet_cli/app.py
+++ b/pushbullet_cli/app.py
@@ -10,6 +10,9 @@ import keyring
 import keyrings.alt
 import pushbullet
 
+reload(sys)
+sys.setdefaultencoding('utf8')
+
 from .__version__ import __version__
 
 


### PR DESCRIPTION
set default encoding to utf8 in order to avoid ascii error when listing pushes on Mac OSX (compatibility with python < 3.x)